### PR TITLE
Add the sample keepalived configurations from the old wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,19 +52,19 @@ A typical setup would be:
 ```
 12 11 * * * /usr/bin/rcron myjob
 ```
-* Configure an external tool to maintain the configured state_file up to date: on the master server, this file must contain the word "active", and the word "passive" on slaves servers. See SampleKeepalivedConfs for instance.
+* Configure an external tool to maintain the configured state_file up to date: on the master server, this file must contain the word "active", and the word "passive" on slaves servers. See the [sample keepalived configurations](sample_keepalived_confs.md) for instance.
 
 ## Principles
 
-Cron jobs needing redundancy are launched by rcron rather than directly by cron. 
+Cron jobs needing redundancy are launched by rcron rather than directly by cron.
 When triggered by the cron deamon, rcron will look at his state file's content,
-looking for the words "active" or "passive": 
+looking for the words "active" or "passive":
 * active: rcron will actually run the command
 * passive: rcron will return immediately
 
 
 So rcron is a dumb tool with a K.I.S.S. design, and doesn't do much by itself:
-* It doesn't guess the machines states (active/passive, aka master/slave). It just rely on external tools (like keepalived or heartbeat or wackamole, or something depending on your business context) or manual interventions to update his state file's content. 
+* It doesn't guess the machines states (active/passive, aka master/slave). It just rely on external tools (like keepalived or heartbeat or wackamole, or something depending on your business context) or manual interventions to update his state file's content.
 * It doe not synchronize crontabs content by itself (do it manually for the jobs needing high availability).  
 * It does not synchronize any data or code needed to run the jobs (consider using NFS, ocfs2, csync2, or similar).
 * If an active server halt or crash while running a cron job, rcron won't transfer this job elsewhere nor relaunch it. But it does try to log enough informations so you can see which jobs got interrupted.
@@ -97,9 +97,8 @@ You would have then something like:
     cluster_name = other_jobs
     state_file = /var/run/rcron/stateB
 ```
-* Configure some HA daemon (keepalived or so) to keep server1 default active for the job group A and server2 active for the job group B. See "Multiple clusters setup" in SampleKeepalivedConfs.
+* Configure some HA daemon (keepalived or so) to keep server1 default active for the job group A and server2 active for the job group B. See "Multiple clusters setup" in the [sample keepalived configurations](sample_keepalived_confs.md).
 
 ## Authors
 
 Benjamin Pineau - ben |dot| pineau |at| gmail |dot| com
-

--- a/sample_keepalived_confs.md
+++ b/sample_keepalived_confs.md
@@ -1,0 +1,184 @@
+Configuration examples
+======================
+
+Sample keepalived configuration files to maintain servers states informations (in state_file) up to date.
+
+Note that keepalived won't update the state_file when exiting. This can be dealt with by tweaking init scripts, or using a monitoring (local) cron job or daemon...
+
+Simple setup, one cluster
+-------------------------
+
+Server1 will be our "active" server by default. Server2 will be passive (won't really execute cron jobs) until server1 is down or unreachable.
+
+server1, rcron.conf:
+
+```
+cluster_name = mycluster
+state_file = /var/run/rcron/state
+default_state = active
+```
+
+server1, keepalived.conf:
+
+```
+vrrp_instance VI_1 {
+  state MASTER
+  interface eth0
+  virtual_router_id 31
+  priority 100
+  advert_int 1
+  authentication {
+    auth_type PASS
+    auth_pass 1111
+  }
+  notify_backup "/bin/echo passive > /var/run/rcron/state"
+  notify_master "/bin/echo active > /var/run/rcron/state"
+  notify_fault "/bin/echo passive > /var/run/rcron/state"
+}
+```
+
+server2, rcron.conf:
+
+```
+cluster_name = mycluster
+state_file = /var/run/rcron/state
+default_state = passive
+```
+
+server2, keepalived.conf (note that only two params changed, "state" and "priority"):
+
+```
+vrrp_instance VI_1 {
+  state SLAVE
+  interface eth0
+  virtual_router_id 31
+  priority 99
+  advert_int 1
+  authentication {
+    auth_type PASS
+    auth_pass 1111
+  }
+  notify_backup "/bin/echo passive > /var/run/rcron/state"
+  notify_master "/bin/echo active > /var/run/rcron/state"
+  notify_fault "/bin/echo passive > /var/run/rcron/state"
+}
+```
+
+Multiple clusters setup
+-----------------------
+
+In this scenario, both severs will run some of the redundant jobs. And both will preempt jobs when the other server is down.
+
+server1, crontab:
+
+```
+12 11 * * * /usr/bin/rcron --conf /etc/rcron/rcron_groupA.conf myjob1
+14 11 * * * /usr/bin/rcron --conf /etc/rcron/rcron_groupB.conf myjob2
+```
+
+server1, rcron_groupA.conf:
+
+```
+cluster_name = mycluster
+state_file = /var/run/rcron/state_groupA
+default_state = active
+```
+
+server1, rcron_groupB.conf:
+
+```
+cluster_name = secondcluster
+state_file = /var/run/rcron/state_groupB
+default_state = passive
+```
+
+server1, keepalived.conf:
+
+```
+vrrp_instance VI_1 {
+    state MASTER
+    interface eth0
+    virtual_router_id 31
+    priority 100
+    advert_int 1
+    authentication {
+      auth_type PASS
+      auth_pass 1111
+    }
+  notify_backup "/bin/echo passive > /var/run/rcron/state_groupA"
+  notify_master "/bin/echo active > /var/run/rcron/state_groupA"
+  notify_fault "/bin/echo passive > /var/run/rcron/state_groupA"
+}
+
+vrrp_instance VI_2 {
+  state SLAVE
+  interface eth0
+  virtual_router_id 32
+  priority 99
+  advert_int 1
+  authentication {
+    auth_type PASS
+    auth_pass 1111
+  }
+  notify_backup "/bin/echo passive > /var/run/rcron/state_groupB"
+  notify_master "/bin/echo active > /var/run/rcron/state_groupB"
+  notify_fault "/bin/echo passive > /var/run/rcron/state_groupB"
+}
+```
+
+server2, crontab:
+
+```
+12 11 * * * /usr/bin/rcron --conf /etc/rcron/rcron_groupA.conf myjob1
+14 11 * * * /usr/bin/rcron --conf /etc/rcron/rcron_groupB.conf myjob2
+```
+
+server2, rcron_groupA.conf:
+
+```
+cluster_name = mycluster
+state_file = /var/run/rcron/state_groupA
+default_state = passive
+```
+
+server2, rcron_groupB.conf:
+
+```
+cluster_name = secondcluster
+state_file = /var/run/rcron/state_groupB
+default_state = active
+```
+
+server2, keepalived.conf:
+
+```
+vrrp_instance VI_1 {
+  state SLAVE
+  interface eth0
+  virtual_router_id 31
+  priority 99
+  advert_int 1
+  authentication {
+    auth_type PASS
+    auth_pass 1111
+  }
+  notify_backup "/bin/echo passive > /var/run/rcron/state_groupA"
+  notify_master "/bin/echo active > /var/run/rcron/state_groupA"
+  notify_fault "/bin/echo passive > /var/run/rcron/state_groupA"
+}
+
+vrrp_instance VI_2 {
+  state MASTER
+  interface eth0
+  virtual_router_id 32
+  priority 100
+  advert_int 1
+  authentication {
+    auth_type PASS
+    auth_pass 1111
+  }
+  notify_backup "/bin/echo passive > /var/run/rcron/state_groupB"
+  notify_master "/bin/echo active > /var/run/rcron/state_groupB"
+  notify_fault "/bin/echo passive > /var/run/rcron/state_groupB"
+}
+```


### PR DESCRIPTION
The readme refers to some sample keepalived configurations, which were on the wiki on Google Code. I have added them to the repository as a markdown document to preserve them.

The samples could be added to a wiki on Github, but personally, i find it really useful to have the documentation right there in the repository.
